### PR TITLE
BUG: write.dbi.ffdf fails when table has one column

### DIFF
--- a/R/ffsql.R
+++ b/R/ffsql.R
@@ -983,7 +983,7 @@ write.dbi.ffdf <- function(x, name,
     dbWriteTable.args <- list(...)
     dbWriteTable.args$conn <- dbiinfo$channel
     dbWriteTable.args$name <- name
-    dbWriteTable.args$value <- x[chunkidx, ]
+    dbWriteTable.args$value <- x[chunkidx, , drop=FALSE]
     if(i > 1 && "overwrite" %in% names(dbWriteTable.args)){
       dbWriteTable.args$overwrite <- FALSE
     }


### PR DESCRIPTION
A classic R anti-feature at work here.
